### PR TITLE
Full mitigation where refresh() is called many times using one Queue

### DIFF
--- a/packages/treeviz/demo/demo.html
+++ b/packages/treeviz/demo/demo.html
@@ -9,6 +9,7 @@
 
     <input type="button" id="add" value="Add data" style="font-size:35px;"></input>
     <input type="button" id="remove" value="Remove data"style="font-size:35px;"></input>
+    <input type="button" id="doTasks" value="Edit data multiple times" style="font-size:35px;"></input>
 
     <div id="tree" style="height:800px;width:1000px"></div>
 
@@ -67,9 +68,31 @@
         onNodeClick : (nodeData) => console.log(nodeData)
     });
     myTree.refresh(data_1);
-    var toggle=true;
-    document.querySelector("#add").addEventListener("click", () => {toggle ? myTree.refresh(data_2) : myTree.refresh(data_3); toggle = false});
-    document.querySelector("#remove").addEventListener("click", () => myTree.refresh(data_1));
+    let toggle=true;
+    let addButton = document.querySelector("#add");
+    let removeButton = document.querySelector("#remove");
+    let doTasksButton = document.querySelector("#doTasks")
+    addButton.addEventListener("click", () => {
+      console.log('addButton clicked');
+      toggle ? myTree.refresh(data_2) : myTree.refresh(data_3); toggle = false;
+    });
+    removeButton.addEventListener("click", () => {
+      console.log('removeButton clicked');
+      myTree.refresh(data_1);
+    });
+    doTasksButton.addEventListener("click", () => {
+      addButton.click();
+      removeButton.click();
+      addButton.click();
+      removeButton.click();
+      removeButton.click();
+      addButton.click();
+      removeButton.click();
+      addButton.click();
+      addButton.click();
+      removeButton.click();
+      removeButton.click();
+    });
 
 </script>
 <style>

--- a/packages/treeviz/src/index.ts
+++ b/packages/treeviz/src/index.ts
@@ -9,6 +9,7 @@ import { drawNodeExit } from "./nodes/node-exit";
 import { drawNodeUpdate } from "./nodes/node-update";
 import { generateBasicTreemap, generateNestedData } from "./prepare-data";
 import { ExtendedHierarchyPointNode, ITreeConfig } from "./typings";
+import { RefreshQueue } from "./utils";
 
 export function create(userSettings: Partial<ITreeConfig>) {
   const defaultSettings: ITreeConfig = {
@@ -97,15 +98,17 @@ export function create(userSettings: Partial<ITreeConfig>) {
   }
 
   function refresh(data: any, newSettings?: Partial<ITreeConfig>) {
-    if (newSettings) {
-      settings = { ...settings, ...newSettings };
-    }
-    const nestedData = generateNestedData(data, settings);
-    const treemap = generateBasicTreemap(settings);
-    const computedTree = treemap(nestedData); // mutation
+    RefreshQueue.add(settings.duration, ()=> {
+      if (newSettings) {
+        settings = { ...settings, ...newSettings };
+      }
+      const nestedData = generateNestedData(data, settings);
+      const treemap = generateBasicTreemap(settings);
+      const computedTree = treemap(nestedData); // mutation
 
-    // @ts-ignore
-    draw(svg, computedTree);
+      // @ts-ignore
+      draw(svg, computedTree);
+    });
   }
 
   function clean(keepConfig: boolean) {

--- a/packages/treeviz/src/utils.ts
+++ b/packages/treeviz/src/utils.ts
@@ -54,3 +54,86 @@ export const setNodeLocation = (
     return "translate(" + xPosition + "," + yPosition + ")";
   }
 };
+
+// RefreshQueue ensures that don't run a refresh while another refresh
+// is in transition.
+export class RefreshQueue {
+  // The queue is an array that contains objects. Each object represents an
+  // refresh action and only they have 2 properties:
+  // {
+  //     callback:          triggers when it's the first of queue and then it
+  //                        becomes null to prevent that callback executes more
+  //                        than once.
+  //     delayNextCallback: when callback is executed, queue will subtracts
+  //                        milliseconds from it. When it becomes 0, the entire
+  //                        object is destroyed (shifted) from the array and then
+  //                        the next item (if exists) will be executed similary
+  //                        to this.
+  // }
+  private static queue: Array<{ delayNextCallback: number, callback: any }> = [];
+
+  // Contains setInterval ID
+  private static runner: number;
+
+  // Milliseconds of each iteration
+  private static runnerSpeed: number = 100;
+
+  // Developer internal magic number. Time added at end of refresh transition to
+  // let DOM and d3 rest before another refresh.
+  // 0 creates console and visual errors because getFirstDisplayedAncestor never
+  // found the needed id and setNodeLocation receives undefined parameters.
+  // Between 50 and 100 milliseconds seems enough for 10 nodes (demo example)
+  private static readonly extraDelayBetweenCallbacks: number = 100;
+
+  // Developer internal for debugging RefreshQueue class. Set true to see
+  // console "real time" queue of tasks.
+  // If there is a cleaner method, remove it!
+  private static showQueueLog: boolean = false;
+
+  // Adds one refresh action to the queue. When safe callback will be
+  // triggered
+  public static add(duration: number, callback: () => any) {
+    this.queue.push(
+      {
+        delayNextCallback: duration + this.extraDelayBetweenCallbacks,
+        callback: callback
+      });
+    this.log(this.queue.map(_ => _.delayNextCallback), "<-- New task !!!");
+    if (!this.runner) {
+      this.runnerFunction();
+      //@ts-ignore
+      this.runner = setInterval(() => this.runnerFunction(), this.runnerSpeed);
+    }
+  }
+
+  // Each this.runnerSpeed milliseconds it's executed. It stops when finish.
+  private static runnerFunction() {
+    if (this.queue[0]) {
+      // ************************ Callback section ************************
+      if (this.queue[0].callback) {
+        this.log("Executing task, delaying next task...");
+        try {
+          this.queue[0].callback();
+        } catch (e) {
+          console.error(e);
+        } finally {
+          // To prevent trigger callback more than once
+          this.queue[0].callback = null;
+        }
+      }
+      // ******************** Delay until next callback ********************
+      this.queue[0].delayNextCallback -= this.runnerSpeed;
+      this.log(this.queue.map(_ => _.delayNextCallback));
+      if (this.queue[0].delayNextCallback <= 0) {
+        this.queue.shift();
+      }
+    } else {
+      this.log("No task found");
+      clearInterval(this.runner);
+      this.runner = 0;
+    }
+  };
+
+  // Print to console debug data if this.showQueueLog = true
+  private static log(...msg: any) {if (this.showQueueLog) console.log(...msg)}
+}


### PR DESCRIPTION
This pull request is for fix this issue https://github.com/PierreCapo/treeviz/issues/36

![image](https://user-images.githubusercontent.com/17512287/79327443-bf132d80-7f14-11ea-89d8-f785d1b1d8c5.png)

![image](https://user-images.githubusercontent.com/17512287/79327508-e10cb000-7f14-11ea-9f42-b689bc63cc49.png)

Where one refresh() is executed while another refresh() is transitioning, **node-exit.ts** call **setNodeLocation** with **undefined** variables. 

I added a queue to prevent this bug and for prevent visual glitches where refresh is called repeatedly. It can be tested in demo with "dev" script. You can view queue in console changing `private static showQueueLog: boolean = false` to `true` in **utils.ts**

Now all refresh() calls are queued and they are executed one after the other, waiting transitions.
I think this is it a good solution. Ask me if what you need something or you think another way.

Big regards !!!